### PR TITLE
ENH: Cuda compatibility

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,4 +13,4 @@
 # STYLE: change camelCase to snake_case
 6acf4583eb1362af40cb03db068e139bb29d6b96
 # STYLE: Apply `black` formatting.
-a32ba77d0a821b7b1b15fa238a58cce6d4cf9b82
+649e8d0577431734481590c83651adefbce31777

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -28,11 +28,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install basic dependencies
         run: |
           sudo apt install python3-openslide
           python -m pip install --upgrade pip setuptools wheel
           pip install flake8 pytest itk==${{ matrix.itk-python-git-tag }}
+
+      - name: Install tensorflow
+        run: |
+          pip install tensorflow
 
       - name: Install histomics_stream
         run: |

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setuptools.setup(
         "histomics_stream": "histomics_stream",
     },
     install_requires=[
-        "tensorflow",
+        # tensorflow is not listed as a requirement because the user
+        # will likely want to specify the version for compatibility
+        # with the CUDA libraries, etc.
         "itk",
         "pillow",
         "imagecodecs",


### PR DESCRIPTION
ENH: Removing tensorflow as a required dependency from setup.py because the user will likely wish to specify the specific version for compatibility with the installed CUDA libraries, etc.  Installing (current version of) tensorflow via GitHub action.

Also,
BUG: Fix .git-blame-ignore-revs entry.
