### PR TITLE
ENH: Handle mask_filename=="".

### DIFF
--- a/histomics_stream/dsm/chunk.py
+++ b/histomics_stream/dsm/chunk.py
@@ -70,7 +70,7 @@ class ReadAndSplitChunk:
             mask_chunk = elem["mask_chunk"]
 
         # Handle the case that we need to read from disk
-        read_chunk = not mask_chunk_supplied or tf.math.reduce_any(mask_chunk)
+        read_chunk = not mask_chunk_supplied or tf.math.reduce_max(mask_chunk) > 0
         chunk = tf.constant(0, dtype=tf.uint8)
         if read_chunk:
             chunk = tf.py_function(


### PR DESCRIPTION
Support that some slides will have masks and others might not, by allowing the empty string, "", as the name of a mask file when no mask file is to be supplied.