### PR TITLE
ENH: Use large_image to read whole slide image.

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -9,8 +9,12 @@ jobs:
       max-parallel: 2
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+
         include:
-          - itk-python-git-tag: "v5.2.1"
+          - flake8-python-git-tag: "<4.0.0"
+          - itk-python-git-tag: "==v5.2.1"
+          - pytest-python-git-tag: "<7.0.0"
+          - tensorflow-python-git-tag: "<2.7.0"
 
     steps:
       - uses: actions/checkout@v2
@@ -28,15 +32,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install basic dependencies
+      - name: Install Python dependencies
         run: |
           sudo apt install python3-openslide
           python -m pip install --upgrade pip setuptools wheel
-          pip install flake8 pytest itk==${{ matrix.itk-python-git-tag }}
-
-      - name: Install tensorflow
-        run: |
-          pip install tensorflow
+          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}' 'tensorflow${{ matrix.tensorflow-python-git-tag }}'
+          pip install 'large-image[all]' --find-links https://girder.github.io/large_image_wheels
 
       - name: Install histomics_stream
         run: |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # histomics_stream
 
-Through version 1.0.6, this project was known as tensorflow_reader.
-
 ## Overview
 
-The goal of this project is to create a whole-slide image file reader for TensorFlow. This reader will allow users to extract pixel data from whole-slide image formats, and will support reading paradigms that are commonly used during training and inference.
+The goal of this project is to create a whole-slide image file reader for machine learning with TensorFlow. This reader will allow users to extract pixel data from whole-slide image formats, and will support reading paradigms that are commonly used during training and inference.
 
 ## Installation for Python
 
@@ -23,3 +21,7 @@ import histomics_stream as hs
 ```
 
 This has been tested with `tensorflow:2.6.2-gpu`.
+
+## History
+
+Through version 1.0.6, this project was known as tensorflow_reader.

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 """
 

--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -302,6 +302,21 @@ class CreateTensorFlowDataset:
         level = level.numpy()
 
         if re.compile(r"\.svs$").search(filename):
+            import large_image
+
+            ts = large_image.open(filename)
+            chunk = ts.getRegion(
+                scale=dict(level=level),
+                format=large_image.constants.TILE_FORMAT_NUMPY,
+                region=dict(
+                    left=chunk_left,
+                    top=chunk_top,
+                    width=chunk_right - chunk_left,
+                    height=chunk_bottom - chunk_top,
+                    units="mag_pixels",
+                ),
+            )[0]
+        elif re.compile(r"\.svs$").search(filename):
             import openslide as os
 
             os_obj = os.OpenSlide(filename)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="histomics_stream",
-    version="2.0.0",
+    version="2.1.0",
     author="Lee Newberg",
     author_email="lee.newberg@kitware.com",
     description="A TensorFlow 2 package for reading whole slide images",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
         "pillow",
         "imagecodecs",
         "openslide-python",
+        "large-image[all]",
         "zarr",
         "napari_lazy_openslide",
         "tifffile",


### PR DESCRIPTION
Replace use of `openslide`.