### PR TITLE
ENH: Dataset element is now ((rgb, annotations), None, None).

### DIFF
--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -114,9 +114,12 @@ class CreateTensorFlowDataset:
         # Change study_dataset so that each element is a tile.
         study_dataset = study_dataset.unbatch()
         # print("unbatch done")
-        # Make the tile pixels easier to find in each study_dataset element.
+
+        # Make the tile pixels easier to find in each study_dataset element.  Also, tack
+        # on additional elements to the tuple so that the form is (inputs, targets,
+        # sample_weights).
         study_dataset = study_dataset.map(
-            lambda elem: (elem.pop("tile_pixels"), elem), **self.dataset_map_options
+            lambda elem: ((elem.pop("tile_pixels"), elem), None, None), **self.dataset_map_options
         )
         # print("pop done")
 


### PR DESCRIPTION
Although it is not documented, if it is a tensorflow dataset then the first parameter of `tensorflow.model.predict` can cause something screwy to happen.  I am not 100% sure about this, but it appears that such a first parameter is treated as is the first parameter of `tensorflow.model.fit`.  In particular, if that first parameter is a tuple of length 2 or 3 then it is interpreted as the same length prefix of `(inputs, targets, sample_weights)`.  The previous return value from a callable `histomics_stream.CreateTensorFlowDataset` instance was of the form `(rgb_pixel_values, dictionary_of_annotations)` and the second argument was being misinterpreted as `targets`.  With this pull request, calling an instance of `CreateTensorFlowDataset` instead returns each tensorflow dataset element as `((rgb_pixel_values, dictionary_of_annotations), None, None)`, thus clarifying that the annotations are part of the inputs, not a set of targets.

This pull request will break a part of a late cell in the `histomics_detect/example/wsi_example.ipynb` Jupyter lab.  See https://github.com/PathologyDataScience/histomics_detect/pull/76.