### PR TITLE
ENH: Notebook now runs on Google Colab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ The goal of this project is to create a whole-slide image file reader for machin
 ## Installation for Python
 
 [![PyPI Version](https://img.shields.io/pypi/v/histomics_stream.svg)](https://pypi.python.org/pypi/histomics_stream)
-[![Open In CoLab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/DigitalSlideArchive/histomics_stream/blob/master/example/tensorflow_stream.ipynb?authuser=1)
+[![GitHub repository](https://img.shields.io/badge/Powered%20by-histomics__stream-blue.svg)](https://github.com/DigitalSlideArchive/histomics_stream)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/DigitalSlideArchive/histomics_stream/blob/master/example/tensorflow_stream.ipynb?authuser=1)
 
 histomics_stream can be easily installed with Python wheels.  If you do not want the installation to be to your current Python environment, you should first create and activate a [Python virtual environment (venv)](https://docs.python.org/3/tutorial/venv.html) to work in.  Then, run the following from the command line:
 
 ```shell-script
-pip uninstall -y large_image tensorflow histomics_stream
-pip install 'large_image[all]' --find-links https://girder.github.io/large_image_wheels
-pip install histomics_stream
+apt update
+apt install -y python3-openslide openslide-tools
+pip uninstall -y histomics_stream large_image tensorflow
+pip install histomics_stream 'large_image[all]' --find-links https://girder.github.io/large_image_wheels
 ```
 
 Launch `python3`, import the histomics_stream package, and use it

--- a/example/tensorflow_stream.ipynb
+++ b/example/tensorflow_stream.ipynb
@@ -29,9 +29,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip uninstall -y large_image tensorflow histomics_stream\n",
-    "!pip install 'large_image[all]' --find-links https://girder.github.io/large_image_wheels\n",
-    "!pip install histomics_stream"
+    "!apt update\n",
+    "!apt install -y python3-openslide openslide-tools\n",
+    "!pip uninstall -y histomics_stream large_image tensorflow\n",
+    "!pip install histomics_stream 'large_image[all]' --find-links https://girder.github.io/large_image_wheels\n",
+    "print(\n",
+    "    \"NOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\"\n",
+    ")"
    ]
   },
   {
@@ -69,6 +73,7 @@
     "mask_filename = os.path.splitext(local_filename)[0] + \"-mask.png\"\n",
     "if not os.path.exists(mask_filename):\n",
     "    import large_image\n",
+    "\n",
     "    print(f\"Creating {mask_filename} ...\")\n",
     "    ts = large_image.open(local_filename)\n",
     "    import numpy as np\n",

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 
 """
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="histomics_stream",
-    version="2.1.2",
+    version="2.1.3",
     author="Lee Newberg",
     author_email="lee.newberg@kitware.com",
     description="A TensorFlow 2 package for reading whole slide images",

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,7 @@ setuptools.setup(
         "histomics_stream": "histomics_stream",
     },
     install_requires=[
-        # tensorflow is not listed as a requirement because the user
-        # will likely want to specify the version for compatibility
-        # with the CUDA libraries, etc.
+        "tensorflow>=2.6.0,<2.7",
         "itk",
         "pillow",
         "imagecodecs",


### PR DESCRIPTION
Bump version to 2.1.3.
Install `python3-openslide`.
Add `tensorflow>=2.6.0,<2.7` dependency.
Add advice that Google Colab may require `Runtime->Restart runtime`.
Add GitHub badge to README.md.

This works in docker and in Python virtual environments, etc, but does not work on Google Colab unless the user selects `Runtime->Restart runtime` after installing the `large_image package`.  A change to `large_image` to work around this is in the works.