### PR TITLE
Fix mismatched float problem

### DIFF
--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 """
 

--- a/histomics_stream/tensorflow.py
+++ b/histomics_stream/tensorflow.py
@@ -232,28 +232,32 @@ class CreateTensorFlowDataset:
         scaled_number_pixel_rows_for_tile = tf.cast(
             tf.math.floor(
                 tf.cast(elem["number_pixel_rows_for_tile"], dtype=tf.float64)
-                / elem["factor"]
-                + 0.01
+                / tf.cast(elem["factor"], dtype=tf.float64)
+                + tf.convert_to_tensor(0.01, dtype=tf.float64)
             ),
             dtype=tf.int32,
         )
         scaled_number_pixel_columns_for_tile = tf.cast(
             tf.math.floor(
                 tf.cast(elem["number_pixel_columns_for_tile"], dtype=tf.float64)
-                / elem["factor"]
-                + 0.01
+                / tf.cast(elem["factor"], dtype=tf.float64)
+                + tf.convert_to_tensor(0.01, dtype=tf.float64)
             ),
             dtype=tf.int32,
         )
         scaled_chunk_top = tf.cast(
             tf.math.floor(
-                tf.cast(elem["chunk_top"], dtype=tf.float64) / elem["factor"] + 0.01
+                tf.cast(elem["chunk_top"], dtype=tf.float64)
+                / tf.cast(elem["factor"], dtype=tf.float64)
+                + tf.convert_to_tensor(0.01, dtype=tf.float64)
             ),
             dtype=tf.int32,
         )
         scaled_chunk_left = tf.cast(
             tf.math.floor(
-                tf.cast(elem["chunk_left"], dtype=tf.float64) / elem["factor"] + 0.01
+                tf.cast(elem["chunk_left"], dtype=tf.float64)
+                / tf.cast(elem["factor"], dtype=tf.float64)
+                + tf.convert_to_tensor(0.01, dtype=tf.float64)
             ),
             dtype=tf.int32,
         )
@@ -273,8 +277,8 @@ class CreateTensorFlowDataset:
                                 tf.cast(
                                     tf.gather(elem["tiles_top"], i), dtype=tf.float64
                                 )
-                                / elem["factor"]
-                                + 0.01
+                                / tf.cast(elem["factor"], dtype=tf.float64)
+                                + tf.convert_to_tensor(0.01, dtype=tf.float64)
                             ),
                             dtype=tf.int32,
                         )
@@ -284,8 +288,8 @@ class CreateTensorFlowDataset:
                                 tf.cast(
                                     tf.gather(elem["tiles_left"], i), dtype=tf.float64
                                 )
-                                / elem["factor"]
-                                + 0.01
+                                / tf.cast(elem["factor"], dtype=tf.float64)
+                                + tf.convert_to_tensor(0.01, dtype=tf.float64)
                             ),
                             dtype=tf.int32,
                         )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="histomics_stream",
-    version="2.1.4",
+    version="2.1.5",
     author="Lee Newberg",
     author_email="lee.newberg@kitware.com",
     description="A TensorFlow 2 package for reading whole slide images",


### PR DESCRIPTION
Tensorflow complains of `tf.float64` vs. `tf.float32` incompatibility in some scenarios.  With this pull request, we are casting everything relevant to `tf.float64`.