### PR TITLE
BUG: Better alignment accuracy between overlapping tiles and mask.

### DIFF
--- a/example/tensorflow_stream.ipynb
+++ b/example/tensorflow_stream.ipynb
@@ -31,13 +31,16 @@
    "source": [
     "!apt update\n",
     "!apt install -y python3-openslide openslide-tools\n",
+    "\n",
     "!pip install histomics_stream 'large_image[openslide,ometiff,openjpeg,bioformats]' pooch --find-links https://girder.github.io/large_image_wheels\n",
-    "!pip install /tf/notebooks/histomics_detect\n",
     "\n",
     "import sys\n",
+    "!pip install /tf/notebooks/histomics_detect\n",
     "sys.path.append(\"/tf/notebooks/histomics_detect/\")\n",
     "\n",
-    "print(\"\\nNOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\")"
+    "print(\n",
+    "    \"\\nNOTE!: On Google Colab you may need to choose 'Runtime->Restart runtime' for these updates to take effect.\"\n",
+    ")"
    ]
   },
   {
@@ -198,7 +201,9 @@
     "# Demonstrate TilesByList\n",
     "my_study_tiles_by_list = copy.deepcopy(my_study0)\n",
     "tiles_by_list = hs.configure.TilesByList(\n",
-    "    my_study_tiles_by_list, randomly_select=5, tiles_dictionary=my_study_tiles_by_grid[\"slides\"][\"Slide_0\"][\"tiles\"]\n",
+    "    my_study_tiles_by_list,\n",
+    "    randomly_select=5,\n",
+    "    tiles_dictionary=my_study_tiles_by_grid[\"slides\"][\"Slide_0\"][\"tiles\"],\n",
     ")\n",
     "# We could apply this to a subset of the slides, but we will apply it to all slides in\n",
     "# this example.\n",
@@ -248,6 +253,7 @@
     "    number_pixel_overlap_rows_for_tile=0,\n",
     "    number_pixel_overlap_columns_for_tile=0,\n",
     "    mask_filename=mask_path,\n",
+    "    mask_threshold=0.5,\n",
     "    randomly_select=100,\n",
     ")\n",
     "for slide in my_study_of_tiles[\"slides\"].values():\n",
@@ -294,7 +300,9 @@
     "# restore keras model\n",
     "from histomics_detect.models import FasterRCNN\n",
     "\n",
-    "model = tf.keras.models.load_model(model_path, custom_objects={\"FasterRCNN\": FasterRCNN})\n",
+    "model = tf.keras.models.load_model(\n",
+    "    model_path, custom_objects={\"FasterRCNN\": FasterRCNN}\n",
+    ")\n",
     "\n",
     "# Each element of the `tiles` tensorflow Dataset is a (rgb_image_data, dictionary_of_annotation) pair.\n",
     "# Wrap the unwrapped_model so that it knows to use the image.\n",
@@ -336,7 +344,9 @@
     "end_time = time.time()\n",
     "number_of_inputs = len([0 for tile in tiles])\n",
     "number_of_predictions = predictions[0].shape[0]\n",
-    "print(f\"Made {number_of_predictions} predictions for {number_of_inputs} tiles in {end_time - start_time} s.\")\n",
+    "print(\n",
+    "    f\"Made {number_of_predictions} predictions for {number_of_inputs} tiles in {end_time - start_time} s.\"\n",
+    ")\n",
     "print(f\"Average of {(end_time - start_time) / number_of_inputs} s per tile.\")"
    ]
   },


### PR DESCRIPTION
ENH: Allow specification of mask_threshold.
ENH: Updated tensorflow_stream.ipynb jupyter lab.

The physical area of a tile on a whole slide image may overlap the physical area of multiple pixels in the mask.  The tile is retained if the fraction of its area that is physically represented by non-zero mask pixels is greater than the specified mask_threshold.  Additionally a bug where overlapping tiles were not properly aligned with the mask has been fixed.