### PR TITLE
ENH: Automatically publish to PyPI

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,9 +12,8 @@ jobs:
 
         include:
           - flake8-python-git-tag: "<4.0.0"
-          - itk-python-git-tag: "==v5.2.1"
+          - itk-python-git-tag: "~=5.2.0"
           - pytest-python-git-tag: "<7.0.0"
-          - tensorflow-python-git-tag: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -37,8 +36,8 @@ jobs:
           sudo apt update
           sudo apt install openslide-tools python3-openslide
           python -m pip install --upgrade pip setuptools wheel
-          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}' 'tensorflow${{ matrix.tensorflow-python-git-tag }}'
-          pip install 'large-image[all]' --find-links https://girder.github.io/large_image_wheels
+          pip install 'flake8${{ matrix.flake8-python-git-tag }}' 'pytest${{ matrix.pytest-python-git-tag }}' 'itk${{ matrix.itk-python-git-tag }}' 'tensorflow'
+          pip install 'large-image[openslide,ometiff,openjpeg,bioformats]' 'scikit_image' --find-links https://girder.github.io/large_image_wheels
 
       - name: Install histomics_stream
         run: |
@@ -56,3 +55,29 @@ jobs:
           cd test
           pytest
         shell: bash
+
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install pypa/build
+      run: >-
+        python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/histomics_stream/__init__.py
+++ b/histomics_stream/__init__.py
@@ -1,6 +1,6 @@
 """Whole-slide image streamer for TensorFlow."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,30 @@
 [build-system]
-requires = [
-         "setuptools>=42",
-         "wheel",
-         "flit_core >=2,<4",
-         ]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "histomics_stream"
+readme = "README.md"
+requires-python = ">=3.6"
+authors = [{name = "Lee A. Newberg", email = "lee.newberg@kitware.com"}]
+maintainers = [{name = "Lee A. Newberg", email = "lee.newberg@kitware.com"}]
+keywords = ["tensorflow", "whole slide image", "stream", "machine learning"]
+classifiers = ["License :: OSI Approved :: Apache Software License"]
+dependencies = [
+    # tensorflow is not listed as a dependency because the user
+    # will likely want to specify the version for compatibility
+    # with the CUDA libraries, presence of GPUs, etc.
+    "imagecodecs",
+    "itk",
+    "numpy",
+    "openslide-python",
+    "pillow",
+    "zarr",
+]
+dynamic = ["version", "description"]
+
+[project.urls]
+Source = "https://github.com/DigitalSlideArchive/histomics_stream"
+
+[project.scripts]
+flit = "flit:main"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="histomics_stream",
-    version="2.2.0",
+    version="2.2.1",
     author="Lee Newberg",
     author_email="lee.newberg@kitware.com",
     description="A TensorFlow 2 package for reading whole slide images",


### PR DESCRIPTION
Modified `.github/workflows/build-test-package.yml` and `pyproject.toml` to enable automatic publishing to PyPITest, and for tagged commits, to PyPI.
